### PR TITLE
fix: Nodes are undefined when connection.data.key doesn't exist

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1514,7 +1514,7 @@ class ScGraphItemView extends ItemView {
 				const connectionId = connection.key;
 				// console.log('Adding connection node for ID:', connectionId);
 
-				this.addConnectionNode(connection);
+				this.addConnectionNode(connectionId, connection);
 				// console.log('Adding connection link for ID:', connectionId);
 
 				this.addConnectionLink(connectionId, connection);
@@ -1526,12 +1526,12 @@ class ScGraphItemView extends ItemView {
 		// console.log('Links after addFilteredConnections:', this.links);	
 	}
 
-	addConnectionNode(connection: any) {
-		if (!this.nodes.some((node: { id: string; }) => node.id === connection.data.key)) {
+	addConnectionNode(connectionId: any, connection: any) {
+		if (!this.nodes.some((node: { id: string; }) => node.id === connectionId)) {
 			this.nodes.push({
-				id: connection.data.key,
-				name: connection.data.key,
-				group: (connection instanceof this.env.item_types.SmartBlock) ? 'block' : 'note',				
+				id: connectionId,
+				name: connectionId,
+				group: (connection instanceof this.env.item_types.SmartBlock) ? 'block' : 'note',
 				x: Math.random() * 1000,
 				y: Math.random() * 1000,
 				fx: null,
@@ -1541,7 +1541,7 @@ class ScGraphItemView extends ItemView {
 				highlighted: false
 			});
 		} else {
-			console.log('Node already exists for connection ID:',connection.data.key);
+			console.log('Node already exists for connection ID:',connectionId);
 		}
 	}
 	


### PR DESCRIPTION
I ran into an issue today where my graph view wasn't loading, with these errors in the console:

```
plugin:smart-connections-visualizer:5788 Target node not found: <my file>.md
```

Upon inspection in the debugger, I found that `this.nodes` only had the central node set, every other node was being skipped because `connection.data.key` didn't exist in the `connection` object when trying to draw the graph.

I saw what I thought was a discrepancy, where nodes are being added to the graph by `connection.key`, but are then being checked for presence in the graph by `connection.data.key`. Since `connection.key` is required to be truthy for earlier code to work, it seemed like the appropriate fix was to use `connection.key` to check for a node's presence in the graph. I changed this locally and it caused the graph to render as expected.